### PR TITLE
[FIX] Constructor directory typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@
       _classCallCheck(this, Keybinder);
 
       this.id = 'org.gnome.shell.extensions.' + id;
-      this.directory = directory;
+      this.dir = directory;
       this.bindings = [];
     }
 

--- a/keybinder.js
+++ b/keybinder.js
@@ -22,7 +22,7 @@ export default class Keybinder {
    */
   constructor(id, directory=GLib.get_tmp_dir()) {
     this.id = `org.gnome.shell.extensions.${id}`;
-    this.directory = directory;
+    this.dir = directory;
     this.bindings = [];
   }
 


### PR DESCRIPTION
I tried using your library for a shell extension of mine to no avail, only to find that there's a possible typo in your source. This fix seems to have worked for me, but please add further comment if I may have just done something wrong. Thanks.